### PR TITLE
Hotfix utils - add steps options in kinetic block

### DIFF
--- a/src/mf6rtm/utils.py
+++ b/src/mf6rtm/utils.py
@@ -336,7 +336,7 @@ def generate_kinetics_block(kinetics_dict, i):
         The KINETICS block as a string.
     """
     script = f"KINETICS {i+1}\n"
-    options = ["m0", "parms", "formula"]
+    options = ["m0", "parms", "formula", "steps"]
     for species, values in kinetics_dict.items():
         script += f"    {species}\n"
         for k in range(len(values)):


### PR DESCRIPTION
Add `- steps` options in the kinetic block helper function in utils. Now this function can help writting something like this:


KINETICS 12
    Orgc
        -m0 0.00000e+00
        -parms 1.57000e-09 1.67000e-11 1.00000e-13
        -formula Orgc -1.0 CH2O 1.0
        -steps 8.640000e+04 in 1 steps
