### PR TITLE
fix from_mf6 aux variables packages

### DIFF
--- a/autotest/test_benchmark.py
+++ b/autotest/test_benchmark.py
@@ -267,7 +267,92 @@ def build_mf6_1d_injection_model(mup3d, nper, tdis_rc, length_units, time_units,
 
     sim.write_simulation()
     # utils.prep_bins(sim_ws, src_path=src_path, get_only=['mf6', 'libmf6'], add_platform=False)
-    
+
+    return sim
+
+def build_mf6_1d_transport_first_model(sim_ws, name, nper, tdis_rc, length_units, time_units,
+                                       nlay, nrow, ncol, delr, delc, top, botm, wel_spd, chdspd,
+                                       prsity, k11, k33, dispersivity, icelltype, strt,
+                                       hclose, rclose, relax, nouter, ninner):
+    """Build a transport-first sim for Mup3d.from_mf6: GWF + one tracer GWT.
+
+    Same physics as ``build_mf6_1d_injection_model`` but the WEL carries a single
+    ``tracer`` auxiliary and there is exactly one conservative tracer GWT (SSM
+    sourcing that aux). ``from_mf6`` clones this GWT into one reactive GWT per
+    PHREEQC component at ``write_simulation()``.
+    """
+    gwfname = 'gwf'
+    sim = flopy.mf6.MFSimulation(sim_name=name, sim_ws=sim_ws, exe_name='mf6')
+    flopy.mf6.ModflowTdis(sim, nper=nper, perioddata=tdis_rc, time_units=time_units)
+
+    gwf = flopy.mf6.ModflowGwf(sim, modelname=gwfname, save_flows=True,
+                               model_nam_file=f"{gwfname}.nam")
+    imsgwf = flopy.mf6.ModflowIms(
+        sim, complexity="complex", print_option="SUMMARY", outer_dvclose=hclose,
+        outer_maximum=nouter, under_relaxation="NONE", inner_maximum=ninner,
+        inner_dvclose=hclose, rcloserecord=rclose, linear_acceleration="CG",
+        scaling_method="NONE", reordering_method="NONE", relaxation_factor=relax,
+        filename=f"{gwfname}.ims",
+    )
+    sim.register_ims_package(imsgwf, [gwf.name])
+
+    flopy.mf6.ModflowGwfdis(
+        gwf, length_units=length_units, nlay=nlay, nrow=nrow, ncol=ncol, delr=delr,
+        delc=delc, top=top, botm=botm, idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        filename=f"{gwfname}.dis",
+    )
+    flopy.mf6.ModflowGwfnpf(
+        gwf, save_flows=True, save_saturation=True, icelltype=icelltype, k=k11, k33=k33,
+        save_specific_discharge=True, filename=f"{gwfname}.npf",
+    )
+    flopy.mf6.ModflowGwfic(gwf, strt=strt, filename=f"{gwfname}.ic")
+    # single 'tracer' aux; from_mf6 strips it and writes one aux per component
+    flopy.mf6.ModflowGwfwel(
+        gwf, stress_period_data=wel_spd, save_flows=True, auxiliary=['tracer'],
+        pname='wel', filename=f"{gwfname}.wel",
+    )
+    flopy.mf6.ModflowGwfchd(
+        gwf, maxbound=len(chdspd), stress_period_data=chdspd, save_flows=False,
+        pname="CHD", filename=f"{gwfname}.chd",
+    )
+    flopy.mf6.ModflowGwfoc(
+        gwf, head_filerecord=f"{gwfname}.hds", budget_filerecord=f"{gwfname}.cbb",
+        saverecord=[("HEAD", "ALL"), ("BUDGET", "ALL")],
+    )
+
+    # one conservative tracer GWT used as the from_mf6 template
+    gwtname = 'tracer'
+    gwt = flopy.mf6.MFModel(sim, model_type="gwt6", modelname=gwtname,
+                            model_nam_file=f"{gwtname}.nam")
+    imsgwt = flopy.mf6.ModflowIms(
+        sim, print_option="SUMMARY", outer_dvclose=hclose, outer_maximum=nouter,
+        under_relaxation="NONE", inner_maximum=ninner, inner_dvclose=hclose,
+        rcloserecord=rclose, linear_acceleration="BICGSTAB", scaling_method="NONE",
+        reordering_method="NONE", relaxation_factor=relax, filename=f"{gwtname}.ims",
+    )
+    sim.register_ims_package(imsgwt, [gwt.name])
+    flopy.mf6.ModflowGwtdis(
+        gwt, length_units=length_units, nlay=nlay, nrow=nrow, ncol=ncol, delr=delr,
+        delc=delc, top=top, botm=botm, idomain=np.ones((nlay, nrow, ncol), dtype=int),
+        filename=f"{gwtname}.dis",
+    )
+    flopy.mf6.ModflowGwtic(gwt, strt=0.0, filename=f"{gwtname}.ic")
+    flopy.mf6.ModflowGwtssm(gwt, sources=['wel', 'aux', 'tracer'], save_flows=True,
+                            filename=f"{gwtname}.ssm")
+    flopy.mf6.ModflowGwtadv(gwt, scheme="tvd")
+    alpha_l = np.ones((nlay, nrow, ncol)) * dispersivity
+    ath1 = np.ones((nlay, nrow, ncol)) * dispersivity * 0.1
+    atv = np.ones((nlay, nrow, ncol)) * dispersivity * 0.1
+    flopy.mf6.ModflowGwtdsp(gwt, xt3d_off=True, alh=alpha_l, ath1=ath1, atv=atv,
+                            filename=f"{gwtname}.dsp")
+    flopy.mf6.ModflowGwtmst(gwt, porosity=prsity, first_order_decay=None,
+                            filename=f"{gwtname}.mst")
+    flopy.mf6.ModflowGwtoc(
+        gwt, budget_filerecord=f"{gwtname}.cbb", concentration_filerecord=f"{gwtname}.ucn",
+        saverecord=[("CONCENTRATION", "ALL"), ("BUDGET", "ALL")],
+    )
+    flopy.mf6.ModflowGwfgwt(sim, exgtype="GWF6-GWT6", exgmnamea=gwfname,
+                            exgmnameb=gwtname, filename=f"{gwtname}.gwfgwt")
     return sim
 
 def build_mf6_2d_model(mup3d, nper, tdis_rc, length_units, time_units, nlay, nrow, ncol, delr, delc,
@@ -1083,6 +1168,122 @@ def test05(request, prefix = 'test05'):
                                         strt, rclose, relax, nouter, ninner)
     
     run_test(prefix, model, request=request, test_cli=True, libname=lib_name, treshold = 0.02)
+
+def test05_from_mf6(request, prefix = 'test05'):
+    '''Test 5 via the transport-first from_mf6 workflow.
+
+    Same pyrite 1D oxidation column as test05 (equilibrium phases, SCM, kinetics,
+    exchange), but built by wrapping an existing flopy sim (GWF + one conservative
+    tracer GWT) with Mup3d.from_mf6 and switching the injected solution per stress
+    period through ChemStress('wel', type='aux').set_spd({0:[2], 1:[3]}). The output
+    must match the same benchmark as test05 (benchmark/test05_benchmark.csv).
+    '''
+    # General
+    length_units = "meters"
+    time_units = "days"
+
+    # Model discretization (identical to test05)
+    nlay = 1
+    Lx = 0.053
+    ncol = 16
+    nrow = 1
+    delr = Lx/ncol
+    delc = 1
+    top = 2.87433E-03
+    zbotm = 0.
+    botm = np.linspace(top, zbotm, nlay + 1)[1:]
+
+    # tdis
+    nper = 2
+    nstp = [64, 100]
+    perlen = [0.9333, 1.45833]
+    tsmult = [1.0, 1.0]
+    tdis_rc = [(kper, kstep, ts) for kper, kstep, ts in zip(perlen, nstp, tsmult)]
+
+    # injection — WEL carries one 'tracer' aux (placeholder value); from_mf6
+    # replaces it with one aux column per component using the ChemStress mapping.
+    q = 2.4e-4
+    wel_spd = {i: [[(0, 0, 0), q, 1.0]] for i in range(0, len(perlen))}
+
+    # hydraulic properties
+    prsity = 0.376
+    k11 = 1.0
+    k33 = k11
+    r_hd = 1
+    strt = np.ones((nlay, nrow, ncol), dtype=float)
+    chdspd = [[(i, 0, ncol-1), r_hd] for i in range(nlay)]
+
+    # transport
+    dispersivity = 0.00537
+    icelltype = 1
+    nouter, ninner = 300, 600
+    hclose, rclose, relax = 1e-6, 1e-6, 1.0
+
+    # chemistry (identical to test05)
+    solutionsdf = pd.read_csv(os.path.join(dataws, f"{prefix}_solutions.csv"), comment='#', index_col=0)
+    solutions = utils.solution_df_to_dict(solutionsdf)
+    sol_ic = np.ones((nlay, nrow, ncol), dtype=float)
+    solution = mup3d.Solutions(solutions)
+    solution.set_ic(sol_ic)
+
+    excdf = pd.read_csv(os.path.join(dataws, f"{prefix}_exchange.csv"), comment='#', index_col=0)
+    excdf.columns = [0, 1, 2, 3]
+    exchanger_dict = excdf.to_dict()
+    for k, subdict in exchanger_dict.items():
+        for key in subdict:
+            subdict[key] = {'m0': subdict[key]}
+    exchanger = mup3d.ExchangePhases(exchanger_dict)
+    exchanger_ic = np.ones((nlay, nrow, ncol), dtype=float)
+    exchanger_ic[0, 0, :4] = 1
+    exchanger_ic[0, 0, 4:8] = 2
+    exchanger_ic[0, 0, 8:12] = 3
+    exchanger_ic[0, 0, 12:] = 4
+    exchanger.set_ic(exchanger_ic)
+    exchanger.set_equilibrate_solutions([1, 1, 1, 1])
+
+    df = pd.read_csv(os.path.join(dataws, f"{prefix}_kinetic_phases.csv"))
+    kin_phases = utils.parse_kinetics_dataframe(df)
+    kin_phases[1]['Orgc_sed']['formula'] = 'Orgc_sed -1.0 C 1.0'
+    kinetics = mup3d.KineticPhases(kin_phases)
+    kinetics.set_ic(1)
+
+    df = pd.read_csv(os.path.join(dataws, f"{prefix}_equilibrium_phases.csv"))
+    equ_phases = utils.parse_equilibriums_dataframe(df)
+    equilibriums = mup3d.EquilibriumPhases(equ_phases)
+    equilibriums.set_ic(1)
+
+    surfdic = utils.surfaces_csv_to_dict(os.path.join(dataws, f"{prefix}_surfaces.csv"))
+    surfaces = mup3d.Surfaces(surfdic)
+    surfaces.set_ic(1)
+
+    # transport-first flopy sim: GWF + single conservative tracer GWT
+    src_ws = os.path.join(cwd, f'{prefix}_from_mf6_src')
+    sim = build_mf6_1d_transport_first_model(
+        src_ws, prefix, nper, tdis_rc, length_units, time_units, nlay, nrow, ncol,
+        delr, delc, top, botm, wel_spd, chdspd, prsity, k11, k33, dispersivity,
+        icelltype, strt, hclose, rclose, relax, nouter, ninner,
+    )
+
+    # build the reactive model by cloning the tracer GWT per component
+    model = mup3d.Mup3d.from_mf6(sim, solution, name=prefix, gwt_name='tracer')
+    model.set_wd(os.path.join(cwd, f'{prefix}_from_mf6'))
+    model.set_database(os.path.join(databasews, 'ex5.dat'))
+    model.set_initial_temp([7., 7., 7.])
+    model.set_postfix(os.path.join(dataws, f'{prefix}_postfix.phqr'))
+    model.set_exchange_phases(exchanger)
+    model.set_phases(kinetics)
+    model.set_phases(equilibriums)
+    model.set_phases(surfaces)
+    model.initialize()
+
+    wellchem = mup3d.ChemStress('wel', type='aux')
+    wellchem.set_spd({0: [2], 1: [3]})  # period 0 -> solution 2, period 1 -> solution 3
+    model.set_chem_stress(wellchem)
+
+    model.write_simulation()
+
+    # compare against the SAME benchmark as test05
+    run_test(prefix, model, request=request, test_cli=True, libname=lib_name, treshold=0.02)
 
 def test_mf6_bin():
     '''Test that mf6 binary is available'''

--- a/autotest/test_mup3d.py
+++ b/autotest/test_mup3d.py
@@ -819,13 +819,20 @@ class TestFromMf6:
     """Structural tests for Mup3d.from_mf6 — no MF6 run required."""
 
     @staticmethod
-    def _build_minimal_sim(sim_ws):
-        """Minimal flopy sim: 3-cell GWF + tracer GWT with CHD aux + SSM."""
+    def _build_minimal_sim(sim_ws, nper=1):
+        """Minimal flopy sim: 3-cell GWF + tracer GWT with CHD aux + SSM.
+
+        ``nper`` stress periods are created; the inflow CHD (``chdin``) carries a
+        ``tracer`` aux and is given SPD rows for every period so per-period aux
+        expansion has something to attach to.
+        """
         import flopy
         sim = flopy.mf6.MFSimulation(
             sim_name='test', sim_ws=str(sim_ws), exe_name='mf6'
         )
-        flopy.mf6.ModflowTdis(sim, nper=1, perioddata=[(1.0, 1, 1.0)], time_units='days')
+        flopy.mf6.ModflowTdis(sim, nper=nper,
+                              perioddata=[(1.0, 1, 1.0)] * nper,
+                              time_units='days')
 
         gwf = flopy.mf6.ModflowGwf(sim, modelname='gwf', save_flows=True)
         ims_gwf = flopy.mf6.ModflowIms(sim, filename='gwf.ims')
@@ -836,8 +843,9 @@ class TestFromMf6:
                                  filename='gwf.dis')
         flopy.mf6.ModflowGwfnpf(gwf, k=1.0, filename='gwf.npf')
         flopy.mf6.ModflowGwfic(gwf, strt=1.0, filename='gwf.ic')
+        chdin_spd = {k: [[(0, 0, 0), 1.0, 1.0]] for k in range(nper)}
         flopy.mf6.ModflowGwfchd(
-            gwf, stress_period_data=[[(0, 0, 0), 1.0, 1.0]],
+            gwf, stress_period_data=chdin_spd,
             auxiliary=['tracer'], pname='chdin', filename='gwf.chdin.chd',
         )
         flopy.mf6.ModflowGwfchd(
@@ -909,6 +917,58 @@ class TestFromMf6:
             assert f'{c}.ims' in written, f'Missing IMS for {c}'
             assert f'{c}.cncout.cnc' in written, f'Missing CNC file for {c}'
             assert f'{c}.gwfgwt' in written, f'Missing exchange for {c}'
+
+    def test_aux_per_period_switches_solution(self, tmp_path, benchmark_database):
+        """type='aux' with a per-period dict writes distinct aux columns per period.
+
+        Regression for from_mf6 aux ChemStress: set_spd({0:[2], 1:[3]}) must expand
+        the tracer aux into one column per component *per stress period* (period 0 =
+        solution 2, period 1 = solution 3). Previously the aux path indexed cs.data by
+        cell only, so a per-period dict produced wrong-width rows (MFDataException) and
+        never switched solution.
+        """
+        sim_ws = tmp_path / 'perperiod'
+        sim_ws.mkdir()
+        sim = self._build_minimal_sim(sim_ws, nper=2)
+
+        # three solutions (1,2,3) so per-period numbers 2 and 3 are valid
+        solutions = Solutions({'Ca': [1e-4, 1e-3, 5e-3], 'Cl': [2e-4, 2e-3, 5e-3]})
+        solutions.set_ic(1)
+
+        model = Mup3d.from_mf6(sim, solutions, name='test', gwt_name='gwt')
+        model.set_database(benchmark_database)
+        model.initialize()
+        ncomps = len(model.components)
+
+        chdin_cs = ChemStress('chdin', type='aux')
+        chdin_cs.set_spd({0: [2], 1: [3]})
+        model.set_chem_stress(chdin_cs)
+
+        # must not raise MFDataException about the wrong number of columns
+        model.write_simulation()
+
+        gwf_name = next(
+            n for n in model._gwt_sim.model_names
+            if model._gwt_sim.get_model(n).model_type == 'gwf6'
+        )
+        pkg = model._gwt_sim.get_model(gwf_name).get_package('chdin')
+        spd = pkg.stress_period_data.get_data()
+
+        # chdin record is (cellid, head, *concs) -> width = 2 base fields + ncomps,
+        # and the trailing ncomps fields are the component aux columns.
+        rec0 = tuple(spd[0][0])
+        rec1 = tuple(spd[1][0])
+        assert len(rec0) == 2 + ncomps
+        assert len(rec1) == 2 + ncomps
+        aux0 = rec0[-ncomps:]
+        aux1 = rec1[-ncomps:]
+
+        # each period carries its mapped solution's equilibrated concentrations
+        np.testing.assert_allclose(aux0, tuple(model.chdin.data[0][0]))
+        np.testing.assert_allclose(aux1, tuple(model.chdin.data[1][0]))
+
+        # the solution actually switched between the two periods
+        assert aux0 != aux1
 
     def test_cnc_missing_cells_raises(self, tmp_path, benchmark_database):
         """cnc ChemStress without set_cells raises ValueError at write_simulation."""

--- a/autotest/test_solver.py
+++ b/autotest/test_solver.py
@@ -1,0 +1,153 @@
+import numpy as np
+from unittest.mock import MagicMock
+
+from mf6rtm.simulation.solver import (
+    Mf6RTM,
+    get_conc_change_mask,
+    get_inactive_idx,
+    get_less_than_zero_idx,
+    longest_common_substring,
+)
+
+
+def _make_mock_mf6rtm(reactive=True, timing='all', tsteps=None, kper=1, kstp=1):
+    """Minimal mock Mf6RTM for is_reactive_tstep (no model run)."""
+    mock = MagicMock()
+    mock.reactive = reactive
+    mock.mf6api.kper = kper
+    mock.mf6api.kstp = kstp
+    mock.config.reactive = {'timing': timing, 'tsteps': tsteps or []}
+    return mock
+
+
+class TestIsReactiveTstep:
+    """Test suite for Mf6RTM.is_reactive_tstep timing logic."""
+
+    def test_non_reactive_returns_false(self):
+        mock = _make_mock_mf6rtm(reactive=False)
+        assert Mf6RTM.is_reactive_tstep(mock) is False
+
+    def test_timing_all_returns_true(self):
+        mock = _make_mock_mf6rtm(timing='all')
+        assert Mf6RTM.is_reactive_tstep(mock) is True
+
+    def test_timing_user_matching_tstep(self):
+        # current_tstep is built as [kper, kstp], so tsteps must hold a matching list
+        mock = _make_mock_mf6rtm(timing='user', tsteps=[[1, 2]], kper=1, kstp=2)
+        assert Mf6RTM.is_reactive_tstep(mock) is True
+
+    def test_timing_user_non_matching_tstep(self):
+        mock = _make_mock_mf6rtm(timing='user', tsteps=[[9, 9]], kper=1, kstp=2)
+        assert Mf6RTM.is_reactive_tstep(mock) is False
+
+    def test_unknown_timing_warns_and_defaults_true(self, capsys):
+        mock = _make_mock_mf6rtm(timing='adaptive')
+        result = Mf6RTM.is_reactive_tstep(mock)
+        assert result is True
+        assert 'Unknown strategy' in capsys.readouterr().out
+
+
+class TestGetConcChangeMask:
+    """Test suite for get_conc_change_mask (active/inactive cell mask)."""
+
+    def test_shape_and_binary_values(self):
+        """Mask is 1D of length nxyz with values only in {0, 1}."""
+        ci = np.array([[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]])
+        ck = np.array([[1.0, 2.0, 1.0], [2.0, 2.0, 2.0]])
+        mask = get_conc_change_mask(ck, ci)
+        assert mask.shape == (3,)
+        assert set(np.unique(mask)).issubset({0, 1})
+
+    def test_no_change_gives_all_zero(self):
+        """Identical current/previous arrays -> no cell flagged active."""
+        ci = np.array([[1.0, 5.0, 3.0], [2.0, 2.0, 2.0]])
+        ck = ci.copy()
+        mask = get_conc_change_mask(ck, ci)
+        np.testing.assert_array_equal(mask, np.zeros(3))
+
+    def test_single_component_change_flags_cell(self):
+        """A change in any one component activates that cell only."""
+        ci = np.array([[1.0, 1.0, 1.0], [2.0, 2.0, 2.0]])
+        ck = np.array([[1.0, 2.0, 1.0], [2.0, 2.0, 2.0]])  # cell 1, comp 0 changed
+        mask = get_conc_change_mask(ck, ci)
+        np.testing.assert_array_equal(mask, np.array([0, 1, 0]))
+
+    def test_division_by_zero_is_safe(self):
+        """Zeros in the previous array must not produce NaN/inf."""
+        ci = np.array([[0.0, 1.0, 0.0]])
+        ck = np.array([[5.0, 1.0, 0.0]])
+        mask = get_conc_change_mask(ck, ci)
+        assert np.isfinite(mask).all()
+        assert set(np.unique(mask)).issubset({0, 1})
+
+    def test_threshold_sensitivity(self):
+        """A small relative change is active under a tight threshold and
+        inactive under a loose one."""
+        ci = np.array([[1.0]])
+        ck = np.array([[1.0 + 1e-6]])
+        # default tight threshold -> change is significant -> active
+        assert get_conc_change_mask(ck, ci)[0] == 1
+        # loose threshold swallows the change -> inactive
+        assert get_conc_change_mask(ck, ci, threshold=1e-3)[0] == 0
+
+
+class TestGetInactiveIdx:
+    """Test suite for get_inactive_idx (cells >= sentinel value)."""
+
+    def test_returns_indices_at_or_above_val(self):
+        arr = np.array([1.0, 1e30, 5.0, 2e30])
+        assert get_inactive_idx(arr) == [1, 3]
+
+    def test_returns_list_type(self):
+        arr = np.array([1e30, 0.0])
+        assert isinstance(get_inactive_idx(arr), list)
+
+    def test_empty_when_none_inactive(self):
+        arr = np.array([1.0, 2.0, 3.0])
+        assert get_inactive_idx(arr) == []
+
+    def test_custom_threshold(self):
+        arr = np.array([1.0, 10.0, 100.0])
+        assert get_inactive_idx(arr, val=10.0) == [1, 2]
+
+
+class TestGetLessThanZeroIdx:
+    """Test suite for get_less_than_zero_idx (negative-value locations)."""
+
+    def test_returns_tuple(self):
+        arr = np.array([-1.0, 2.0, -3.0])
+        idx = get_less_than_zero_idx(arr)
+        assert isinstance(idx, tuple)
+
+    def test_one_dimensional_indices(self):
+        arr = np.array([-1.0, 2.0, -3.0, 4.0])
+        np.testing.assert_array_equal(get_less_than_zero_idx(arr)[0], [0, 2])
+
+    def test_two_dimensional_indices(self):
+        arr = np.array([[1.0, -2.0], [-3.0, 4.0]])
+        rows, cols = get_less_than_zero_idx(arr)
+        np.testing.assert_array_equal(rows, [0, 1])
+        np.testing.assert_array_equal(cols, [1, 0])
+
+    def test_empty_when_no_negatives(self):
+        arr = np.array([0.0, 1.0, 2.0])
+        assert len(get_less_than_zero_idx(arr)[0]) == 0
+
+
+class TestLongestCommonSubstring:
+    """Test suite for longest_common_substring (GWT model-name stem)."""
+
+    def test_common_stem(self):
+        assert longest_common_substring(["gwtca", "gwtcl", "gwtna"]) == "gwt"
+
+    def test_longer_shared_prefix(self):
+        assert longest_common_substring(["GWT_ca", "GWT_cl"]) == "GWT_c"
+
+    def test_empty_list_returns_empty(self):
+        assert longest_common_substring([]) == ""
+
+    def test_no_common_substring(self):
+        assert longest_common_substring(["abc", "xyz"]) == ""
+
+    def test_case_sensitive(self):
+        assert longest_common_substring(["GWT", "gwt"]) == ""

--- a/mf6rtm/mup3d/base.py
+++ b/mf6rtm/mup3d/base.py
@@ -1054,6 +1054,12 @@ class Mup3d(object):
             )
             spd = pkg.stress_period_data.get_data()
             ncomps = len(self.components)
+            # cs.data is either flat {cell_i: concs} (one mapping for the whole
+            # run) or per-period nested {kper: {cell_i: concs}} when set_spd was
+            # given a dict. Detect once, then look up concentrations per period.
+            per_period = bool(cs.data) and isinstance(
+                next(iter(cs.data.values())), dict
+            )
             updated_spd = {}
             for sp, records in spd.items():
                 updated = []
@@ -1061,6 +1067,9 @@ class Mup3d(object):
                     updated_spd[sp] = None
                     # for recharge some spds are none
                     continue
+                # concentrations for this stress period keyed by cell index;
+                # periods absent from a per-period dict get zero chemistry.
+                cell_concs = cs.data.get(sp, {}) if per_period else cs.data
                 for i, rec in enumerate(records):
                     base = tuple(rec)
                     if has_boundnames:
@@ -1068,7 +1077,7 @@ class Mup3d(object):
                         base = base[:-1]
                     if n_existing_aux > 0:
                         base = base[:-n_existing_aux]
-                    concs = cs.data.get(i, [0.0] * ncomps)
+                    concs = cell_concs.get(i, [0.0] * ncomps)
                     row = base + tuple(concs)
                     if has_boundnames:
                         row = row + (boundname,)

--- a/mf6rtm/mup3d/base.py
+++ b/mf6rtm/mup3d/base.py
@@ -1054,9 +1054,8 @@ class Mup3d(object):
             )
             spd = pkg.stress_period_data.get_data()
             ncomps = len(self.components)
-            # cs.data is either flat {cell_i: concs} (one mapping for the whole
-            # run) or per-period nested {kper: {cell_i: concs}} when set_spd was
-            # given a dict. Detect once, then look up concentrations per period.
+            # cs.data is either flat {cell_i: concs} or per-period nested {kper: {cell_i: concs}}
+            # Detect once, then look up concentrations per period.
             per_period = bool(cs.data) and isinstance(
                 next(iter(cs.data.values())), dict
             )

--- a/mf6rtm/simulation/solver.py
+++ b/mf6rtm/simulation/solver.py
@@ -698,7 +698,7 @@ def get_less_than_zero_idx(arr):
 
 
 def get_inactive_idx(arr: np.ndarray, val: float = 1e30):
-    """Function to get the index of all occurrences of <0 in an array"""
+    """Function to get the index of all occurrences >= val (inactive sentinel) in an array"""
     idx = list(np.where(arr >= val)[0])
     return idx
 


### PR DESCRIPTION
When you use ChemStress(type='aux') and set a different solution per period with set_spd({0:[2], 1:[3]}), it broke. MF6 stopped with an error about the wrong number of columns. And using a plain list like set_spd([2]) just used the same solution the whole run — it never switched.

The cnc/src types already did per-period right. This makes the aux type do the same: read the right solution for each period and write those values into the well/CHD aux columns. Plain lists work exactly as before.

Changes
- mf6rtm/mup3d/base.py - aux expansion now picks the correct solution per period.
- autotest/test_mup3d.py - added a 2-period test that checks each period gets its own chemistry.
- autotest/test_solver.py  - Add some isolated solver tests independently to the full stack regressions