### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,26 @@
+cff-version: 1.2.0
+message: If you use this software, please cite it as below.
+title: 'MF6RTM: a python package for predictive reactive transport modeling via the MODFLOW 6 and PHREEQC
+  APIs'
+type: software
+authors:
+- given-names: Pablo
+  family-names: Ortega-Tong
+  orcid: https://orcid.org/0000-0003-4091-4221
+- given-names: Anthony
+  family-names: Aufdenkampe
+  orcid: https://orcid.org/0000-0002-5811-6458
+- given-names: Andres
+  family-names: Prieto-Estrada
+  orcid: https://orcid.org/0000-0002-8984-1177
+- given-names: Allan
+  family-names: Foster
+  orcid: https://orcid.org/0000-0002-3746-4226
+- given-names: Paul
+  family-names: Tomasula
+  orcid: https://orcid.org/0009-0004-8120-5936
+- given-names: Lauren
+  family-names: Mancewicz
+  orcid: https://orcid.org/0009-0002-9622-5636
+repository-code: https://github.com/p-ortega/mf6rtm
+license: BSD-3-Clause


### PR DESCRIPTION
Adds a `CITATION.cff` so GitHub shows a "Cite this repository" button and citation tooling can read machine-readable metadata.

Author names and ORCIDs come from `paper.md`, and the licence from the LICENSE file. Validated with `cffconvert --validate` against schema 1.2.0.

Worth checking the given-name/family-name split per author, since some papers give a single `name` field.